### PR TITLE
Add non-raw insert statement implementation for struct based rows

### DIFF
--- a/row.go
+++ b/row.go
@@ -49,11 +49,8 @@ func (s *GoogleSheetRowStore) RawInsert(rows ...[]interface{}) *googleSheetRawIn
 // Insert will try to infer what is the type of each row and perform certain logic based on the type.
 // For example, a struct will be converted into a map[string]interface{} and then into []interface{} (following the
 // column mapping ordering).
-//
-// There needs to be a lot of type handling here.
-// TODO(edocsss): implement this
 func (s *GoogleSheetRowStore) Insert(rows ...interface{}) *googleSheetInsertStmt {
-	panic("not implemented yet")
+	return newGoogleSheetInsertStmt(s, rows)
 }
 
 // Update applies the given value for each column into the applicable rows.

--- a/row.go
+++ b/row.go
@@ -49,6 +49,11 @@ func (s *GoogleSheetRowStore) RawInsert(rows ...[]interface{}) *googleSheetRawIn
 // Insert will try to infer what is the type of each row and perform certain logic based on the type.
 // For example, a struct will be converted into a map[string]interface{} and then into []interface{} (following the
 // column mapping ordering).
+//
+// A few things to take note:
+// - Only `struct` base type (including a pointer to a struct) is supported.
+// - Each field name corresponds to the column name (case-sensitive).
+// - The mapping between field name and column name can be changed by adding the struct field tag `db:"<col_name>"`.
 func (s *GoogleSheetRowStore) Insert(rows ...interface{}) *googleSheetInsertStmt {
 	return newGoogleSheetInsertStmt(s, rows)
 }

--- a/row_test.go
+++ b/row_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 type testPerson struct {
-	Name string `json:"name" mapstructure:"name"`
-	Age  int    `json:"age" mapstructure:"age"`
-	DOB  string `json:"dob" mapstructure:"dob"`
+	Name string `json:"name" db:"name"`
+	Age  int    `json:"age" db:"age"`
+	DOB  string `json:"dob" db:"dob"`
 }
 
 func TestGoogleSheetRowStore_Integration(t *testing.T) {

--- a/row_test.go
+++ b/row_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 type testPerson struct {
-	Name string `json:"name"`
-	Age  int    `json:"age"`
-	DOB  string `json:"dob"`
+	Name string `json:"name" mapstructure:"name"`
+	Age  int    `json:"age" mapstructure:"age"`
+	DOB  string `json:"dob" mapstructure:"dob"`
 }
 
 func TestGoogleSheetRowStore_Integration(t *testing.T) {
@@ -47,8 +47,20 @@ func TestGoogleSheetRowStore_Integration(t *testing.T) {
 	err = db.RawInsert(
 		[]interface{}{"name1", 10, "1-1-1999"},
 		[]interface{}{"name2", 11, "1-1-2000"},
-		[]interface{}{"name3", 12, "1-1-2001"},
 	).Exec(context.Background())
+	assert.Nil(t, err)
+
+	err = db.Insert(nil).Exec(context.Background())
+	assert.NotNil(t, err)
+
+	err = db.Insert([]interface{}{"name3", 12, "1-1-2001"}).Exec(context.Background())
+	assert.NotNil(t, err)
+
+	err = db.Insert(testPerson{
+		Name: "name3",
+		Age:  12,
+		DOB:  "1-1-2001",
+	}).Exec(context.Background())
 	assert.Nil(t, err)
 
 	err = db.Update(map[string]interface{}{"name": "name4"}).

--- a/stmt.go
+++ b/stmt.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/FreeLeh/GoFreeLeh/internal/google/sheets"
-	"github.com/mitchellh/mapstructure"
 )
 
 type googleSheetSelectStmt struct {
@@ -72,7 +71,7 @@ func (s *googleSheetSelectStmt) Exec(ctx context.Context) error {
 	}
 
 	m := s.buildQueryResultMap(result)
-	return mapstructure.Decode(m, s.output)
+	return mapstructureDecode(m, s.output)
 }
 
 func (s *googleSheetSelectStmt) ensureOutputSlice() error {
@@ -330,7 +329,7 @@ func (s *googleSheetInsertStmt) convertRowToSlice(row interface{}) ([]interface{
 	}
 
 	var output map[string]interface{}
-	if err := mapstructure.Decode(row, &output); err != nil {
+	if err := mapstructureDecode(row, &output); err != nil {
 		return nil, err
 	}
 

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 type person struct {
-	Name string `mapstructure:"name,omitempty"`
-	Age  int    `mapstructure:"age,omitempty"`
-	DOB  string `mapstructure:"dob,omitempty"`
+	Name string `db:"name,omitempty"`
+	Age  int    `db:"age,omitempty"`
+	DOB  string `db:"dob,omitempty"`
 }
 
 func TestGenerateSelect(t *testing.T) {
@@ -257,7 +257,7 @@ func TestGoogleSheetInsertStmt_convertRowToSlice(t *testing.T) {
 		assert.Nil(t, err)
 
 		type dummy struct {
-			Name string `mapstructure:"name"`
+			Name string `db:"name"`
 		}
 
 		result, err = stmt.convertRowToSlice(dummy{Name: "blah"})

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/FreeLeh/GoFreeLeh/internal/google/sheets"
+	"github.com/mitchellh/mapstructure"
 )
 
 func currentTimeMs() int64 {
@@ -70,4 +71,18 @@ func generateColumnName(n int) string {
 	}
 
 	return col
+}
+
+func mapstructureDecode(input interface{}, output interface{}) error {
+	config := &mapstructure.DecoderConfig{
+		Result:  output,
+		TagName: "db",
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
 }


### PR DESCRIPTION
The previous implementation only handles `RawInsert` which takes in `[][]interface{}` directly to present the rows. This is not very ideal in Golang since we tend to use structs to represent an object.

This PR aims to implement an `Insert` method that can take in a struct or a pointer to a struct, convert it into a `map[string]interface{}` internally, and finally into a `[]interface{}` for each row. Note that the final `[]interface{}` is already sorted by the column ordering.

The mapping from the struct field name into the map key can be defined using the struct tag `db` (the default one is `mapstructure`, but to make it more obvious, I changed the tag name to `db`). You can read the `mapstructure` [documentation](https://pkg.go.dev/github.com/mitchellh/mapstructure#hdr-Renaming_Fields) for more details.