### PR TITLE
Improve stability and simplify features

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,22 @@ Examples:
 ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 err := store.Select(&result).Where("name = ? AND age = ?", "bob", 12).Exec(ctx)
 ```
+
+### `Count() *googleSheetCountStmt`
+
+- `Count` returns a statement to perform the actual row counting operation.
+
+#### `googleSheetCountStmt`
+
+##### `Where(condition string, args ...interface{}) *googleSheetCountStmt`
+
+This works exactly the same as the `googleSheetSelectStmt.Where` function. You can refer to the above section for more details.
+
+##### `Exec(ctx context.Context) (uint64, error)`
+
+- This function will actually execute the `SELECT` statement and then counting the number of rows matching the criteria.
+- The number of rows is returned as a `uint64` return value.
+- There is only one API call involved in this function.
  
 ### `Insert(rows ...interface{}) *googleSheetInsertStmt`
 

--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ type Person struct {
 
 // Inserts a bunch of rows.
 // Note that the here matters, and it should follow the GoogleSheetRowStoreConfig.Columns settings.
-_ = store.RawInsert(
-    []interface{}{"name1", 10},
-    []interface{}{"name2", 11},
-    []interface{}{"name3", 12},
+_ = store.Insert(
+	Person{Name: "name1", Age: 10},
+	Person{Name: "name2", Age: 11},
+	Person{Name: "name3", Age: 12},
 ).Exec(context.Background())
 
 // Updates the name column for rows with age = 10
@@ -390,23 +390,35 @@ ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 err := store.Select(&result).Where("name = ? AND age = ?", "bob", 12).Exec(ctx)
 ```
  
-### `RawInsert(rows ...[]interface{}) *googleSheetRawInsertStmt`
+### `Insert(rows ...interface{}) *googleSheetInsertStmt`
 
-- `RawInsert` returns a statement to perform the actual insert operation.
-- The `rows` argument is a slice of an `interface{}` slice.
-- The ordering of the values inside each slice of `interface{}` matters as it is the ordering that this library will use when inserting into the Google Sheet.
+- `Insert` returns a statement to perform the actual insert operation.
+- Each element of the `rows` argument must be a struct or a pointer to a struct. Providing data types will result in an error during `Exec()`.
+- Please note that the struct field name will be used as the column name (case-sensitive). If you want to change the mapping, you can add the struct field tag `db:"<col_name>"`.
 
-> This function is called `RawInsert` because the library is not really concerned with how the values in each row is formed.
-> There is also no type checking involved.
-> In the future, we are thinking of adding an `Insert` function that will provide a simple type checking mechanism.
-
-#### `googleSheetRawInsertStmt`
+#### `googleSheetInsertStmt`
 
 ##### `Exec(ctx context.Context) error`
 
 - This function will actually execute the `INSERT` statement.
 - This works by appending new rows into Google Sheets.
 - There is only one API call involved in this function.
+
+Examples:
+
+```go
+// Without the `db` struct tag, the column name used will be "Name" and "Age".
+type Person struct {
+	Name string `db:"name"`
+	Age int `db:"age"`
+}
+
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+err := store.Insert(
+	Person{Name: "name1", Age: 11},
+    Person{Name: "name2", Age: 12},
+).Exec(ctx)
+```
 
 ### `Update(colToValue map[string]interface{}) *googleSheetUpdateStmt`
  

--- a/internal/google/fixtures/service_account.json
+++ b/internal/google/fixtures/service_account.json
@@ -8,5 +8,5 @@
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-something%40scripts-327408.iam.gserviceaccount.com"
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509"
 }

--- a/models.go
+++ b/models.go
@@ -36,6 +36,7 @@ const (
 	kvFindKeyA1RangeQueryTemplate = "=MATCH(\"%s\", %s, 0)"
 
 	rowGetIndicesQueryTemplate           = "=JOIN(\",\", ARRAYFORMULA(QUERY({%s, ROW(%s)}, \"%s\")))"
+	rwoCountQueryTemplate                = "=COUNT(QUERY(%s, \"%s\"))"
 	rowUpdateModifyWhereNonEmptyTemplate = "%s IS NOT NULL AND %s"
 	rowUpdateModifyWhereEmptyTemplate    = "%s IS NOT NULL"
 

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"regexp"
+	"strconv"
 
 	"github.com/FreeLeh/GoFreeLeh/internal/google/sheets"
 )
@@ -52,6 +53,8 @@ var (
 	defaultRowFullTableRange = "A2:" + generateColumnName(maxColumn-1)
 	rowDeleteRangeTemplate   = "A%d:" + generateColumnName(maxColumn-1) + "%d"
 
+	lastColIdxName = "Col" + strconv.FormatInt(int64(maxColumn+1), 10)
+
 	googleSheetSelectStmtStringKeyword = regexp.MustCompile("^(date|datetime|timeofday)")
 )
 
@@ -76,6 +79,24 @@ type sheetsWrapper interface {
 type colIdx struct {
 	name string
 	idx  int
+}
+
+type colsMapping map[string]colIdx
+
+func (m colsMapping) NameMap() map[string]string {
+	result := make(map[string]string, 0)
+	for col, val := range m {
+		result[col] = val.name
+	}
+	return result
+}
+
+func (m colsMapping) ColIdxNameMap() map[string]string {
+	result := make(map[string]string, 0)
+	for col, val := range m {
+		result[col] = "Col" + strconv.FormatInt(int64(val.idx+1), 10)
+	}
+	return result
 }
 
 type ColumnOrderBy struct {

--- a/models.go
+++ b/models.go
@@ -41,9 +41,10 @@ const (
 	rowUpdateModifyWhereNonEmptyTemplate = "%s IS NOT NULL AND %s"
 	rowUpdateModifyWhereEmptyTemplate    = "%s IS NOT NULL"
 
-	naValue    = "#N/A"
-	errorValue = "#ERROR!"
-	rowTsCol   = "_ts"
+	naValue       = "#N/A"
+	errorValue    = "#ERROR!"
+	rowIdxCol     = "_rid"
+	rowIdxFormula = "=ROW()"
 )
 
 var (

--- a/row.go
+++ b/row.go
@@ -37,15 +37,6 @@ func (s *GoogleSheetRowStore) Select(output interface{}, columns ...string) *goo
 	return newGoogleSheetSelectStmt(s, output, columns)
 }
 
-// RawInsert inserts all the values in `rows` into the table.
-// Note that each value in the `interface{}` is going to be JSON marshalled.
-func (s *GoogleSheetRowStore) RawInsert(rows ...[]interface{}) *googleSheetRawInsertStmt {
-	for i := range rows {
-		rows[i] = append(rows[i], currentTimeMs())
-	}
-	return newGoogleSheetRawInsertStmt(s, rows)
-}
-
 // Insert will try to infer what is the type of each row and perform certain logic based on the type.
 // For example, a struct will be converted into a map[string]interface{} and then into []interface{} (following the
 // column mapping ordering).
@@ -67,6 +58,10 @@ func (s *GoogleSheetRowStore) Update(colToValue map[string]interface{}) *googleS
 
 func (s *GoogleSheetRowStore) Delete() *googleSheetDeleteStmt {
 	return newGoogleSheetDeleteStmt(s)
+}
+
+func (s *GoogleSheetRowStore) Count() *googleSheetCountStmt {
+	return newGoogleSheetCountStmt(s)
 }
 
 func (s *GoogleSheetRowStore) Close(ctx context.Context) error {

--- a/row.go
+++ b/row.go
@@ -29,7 +29,7 @@ type GoogleSheetRowStore struct {
 	sheetName           string
 	scratchpadSheetName string
 	scratchpadLocation  sheets.A1Range
-	colsMapping         map[string]colIdx
+	colsMapping         colsMapping
 	config              GoogleSheetRowStoreConfig
 }
 

--- a/row.go
+++ b/row.go
@@ -144,6 +144,10 @@ func NewGoogleSheetRowStore(
 // Currently, we use this for detecting which rows are really empty for UPDATE without WHERE clause.
 // Otherwise, it will always update all rows (instead of the non-empty rows only).
 func injectTimestampCol(config GoogleSheetRowStoreConfig) GoogleSheetRowStoreConfig {
-	config.Columns = append(config.Columns, rowTsCol)
+	newCols := make([]string, 0, len(config.Columns)+1)
+	newCols = append(newCols, rowIdxCol)
+	newCols = append(newCols, config.Columns...)
+	config.Columns = newCols
+
 	return config
 }

--- a/row_test.go
+++ b/row_test.go
@@ -89,3 +89,8 @@ func TestGoogleSheetRowStore_Integration(t *testing.T) {
 	err = db.Delete().Where("name = ?", "name4").Exec(context.Background())
 	assert.Nil(t, err)
 }
+
+func TestInjectTimestampCol(t *testing.T) {
+	result := injectTimestampCol(GoogleSheetRowStoreConfig{Columns: []string{"col1", "col2"}})
+	assert.Equal(t, GoogleSheetRowStoreConfig{Columns: []string{rowIdxCol, "col1", "col2"}}, result)
+}

--- a/row_test.go
+++ b/row_test.go
@@ -44,9 +44,9 @@ func TestGoogleSheetRowStore_Integration(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Empty(t, out)
 
-	err = db.RawInsert(
-		[]interface{}{"name1", 10, "1-1-1999"},
-		[]interface{}{"name2", 11, "1-1-2000"},
+	err = db.Insert(
+		testPerson{"name1", 10, "1-1-1999"},
+		testPerson{"name2", 11, "1-1-2000"},
 	).Exec(context.Background())
 	assert.Nil(t, err)
 
@@ -79,6 +79,12 @@ func TestGoogleSheetRowStore_Integration(t *testing.T) {
 		Exec(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, expected, out)
+
+	count, err := db.Count().
+		Where("name = ? OR name = ?", "name2", "name3").
+		Exec(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(2), count)
 
 	err = db.Delete().Where("name = ?", "name4").Exec(context.Background())
 	assert.Nil(t, err)

--- a/stmt.go
+++ b/stmt.go
@@ -11,8 +11,7 @@ import (
 	"github.com/FreeLeh/GoFreeLeh/internal/google/sheets"
 )
 
-type googleSheetSelectStmt struct {
-	store     *GoogleSheetRowStore
+type queryBuilder struct {
 	replacer  *strings.Replacer
 	columns   []string
 	where     string
@@ -20,141 +19,87 @@ type googleSheetSelectStmt struct {
 	orderBy   []string
 	limit     uint64
 	offset    uint64
-	output    interface{}
 }
 
-func (s *googleSheetSelectStmt) Where(condition string, args ...interface{}) *googleSheetSelectStmt {
-	s.where = condition
-	s.whereArgs = args
-	return s
+func (q *queryBuilder) Where(condition string, args ...interface{}) *queryBuilder {
+	q.where = condition
+	q.whereArgs = args
+	return q
 }
 
-func (s *googleSheetSelectStmt) OrderBy(ordering []ColumnOrderBy) *googleSheetSelectStmt {
+func (q *queryBuilder) OrderBy(ordering []ColumnOrderBy) *queryBuilder {
 	orderBy := make([]string, 0, len(ordering))
 	for _, o := range ordering {
 		orderBy = append(orderBy, o.Column+" "+string(o.OrderBy))
 	}
 
-	s.orderBy = orderBy
-	return s
+	q.orderBy = orderBy
+	return q
 }
 
-func (s *googleSheetSelectStmt) Limit(limit uint64) *googleSheetSelectStmt {
-	s.limit = limit
-	return s
+func (q *queryBuilder) Limit(limit uint64) *queryBuilder {
+	q.limit = limit
+	return q
 }
 
-func (s *googleSheetSelectStmt) Offset(offset uint64) *googleSheetSelectStmt {
-	s.offset = offset
-	return s
+func (q *queryBuilder) Offset(offset uint64) *queryBuilder {
+	q.offset = offset
+	return q
 }
 
-func (s *googleSheetSelectStmt) Exec(ctx context.Context) error {
-	if err := s.ensureOutputSlice(); err != nil {
-		return err
-	}
-
-	stmt, err := s.generateSelect()
-	if err != nil {
-		return err
-	}
-
-	result, err := s.store.wrapper.QueryRows(
-		ctx,
-		s.store.spreadsheetID,
-		s.store.sheetName,
-		stmt,
-		true,
-	)
-	if err != nil {
-		return err
-	}
-
-	m := s.buildQueryResultMap(result)
-	return mapstructureDecode(m, s.output)
-}
-
-func (s *googleSheetSelectStmt) ensureOutputSlice() error {
-	// Passing an uninitialised slice will not compare to nil due to this: https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/
-	// Only if passing an untyped `nil` will compare to the `nil` in the line below.
-	// Observations as below:
-	//
-	// var o []int
-	// o == nil --> this is true because the compiler knows `o` is nil and of type `[]int`, so the `nil` on the right side is of the same `[]int` type.
-	//
-	// var x interface{} = o
-	// x == nil --> this is false because `o` has been boxed by `x` and the `nil` on the right side is of type `nil` (i.e. nil value of nil type).
-	// x == []int(nil) --> this is true because the `nil` has been casted explicitly to `nil` of type `[]int`.
-	if s.output == nil {
-		return errors.New("select statement output cannot be empty or nil")
-	}
-
-	t := reflect.TypeOf(s.output)
-	if t.Kind() != reflect.Ptr {
-		return errors.New("select statement output must be a pointer to a slice of something")
-	}
-
-	elem := t.Elem()
-	if elem.Kind() != reflect.Slice {
-		return fmt.Errorf("select statement output must be a pointer to a slice of something; current output type: %s", t.Kind().String())
-	}
-
-	return nil
-}
-
-func (s *googleSheetSelectStmt) generateSelect() (string, error) {
+func (q *queryBuilder) Generate() (string, error) {
 	stmt := &strings.Builder{}
 	stmt.WriteString("select")
 
-	if err := s.writeCols(stmt); err != nil {
+	if err := q.writeCols(stmt); err != nil {
 		return "", err
 	}
-	if err := s.writeWhere(stmt); err != nil {
+	if err := q.writeWhere(stmt); err != nil {
 		return "", err
 	}
-	if err := s.writeOrderBy(stmt); err != nil {
+	if err := q.writeOrderBy(stmt); err != nil {
 		return "", err
 	}
-	if err := s.writeOffset(stmt); err != nil {
+	if err := q.writeOffset(stmt); err != nil {
 		return "", err
 	}
-	if err := s.writeLimit(stmt); err != nil {
+	if err := q.writeLimit(stmt); err != nil {
 		return "", err
 	}
 
 	return stmt.String(), nil
 }
 
-func (s *googleSheetSelectStmt) writeCols(stmt *strings.Builder) error {
+func (q *queryBuilder) writeCols(stmt *strings.Builder) error {
 	stmt.WriteString(" ")
 
-	translated := make([]string, 0, len(s.columns))
-	for _, col := range s.columns {
-		translated = append(translated, s.replacer.Replace(col))
+	translated := make([]string, 0, len(q.columns))
+	for _, col := range q.columns {
+		translated = append(translated, q.replacer.Replace(col))
 	}
 
 	stmt.WriteString(strings.Join(translated, ", "))
 	return nil
 }
 
-func (s *googleSheetSelectStmt) writeWhere(stmt *strings.Builder) error {
-	if len(s.where) == 0 {
+func (q *queryBuilder) writeWhere(stmt *strings.Builder) error {
+	if len(q.where) == 0 {
 		return nil
 	}
 
-	nArgs := strings.Count(s.where, "?")
-	if nArgs != len(s.whereArgs) {
-		return fmt.Errorf("number of arguments required in the 'where' clause (%d) is not the same as the number of provided arguments (%d)", nArgs, len(s.whereArgs))
+	nArgs := strings.Count(q.where, "?")
+	if nArgs != len(q.whereArgs) {
+		return fmt.Errorf("number of arguments required in the 'where' clause (%d) is not the same as the number of provided arguments (%d)", nArgs, len(q.whereArgs))
 	}
 
-	where := s.replacer.Replace(s.where)
+	where := q.replacer.Replace(q.where)
 	tokens := strings.Split(where, "?")
 
 	result := make([]string, 0)
 	result = append(result, strings.TrimSpace(tokens[0]))
 
 	for i, token := range tokens[1:] {
-		arg, err := s.convertArg(s.whereArgs[i])
+		arg, err := q.convertArg(q.whereArgs[i])
 		if err != nil {
 			return fmt.Errorf("failed converting 'where' arguments: %v, %w", arg, err)
 		}
@@ -166,7 +111,7 @@ func (s *googleSheetSelectStmt) writeWhere(stmt *strings.Builder) error {
 	return nil
 }
 
-func (s *googleSheetSelectStmt) convertArg(arg interface{}) (string, error) {
+func (q *queryBuilder) convertArg(arg interface{}) (string, error) {
 	switch converted := arg.(type) {
 	case int:
 		return strconv.FormatInt(int64(converted), 10), nil
@@ -207,40 +152,101 @@ func (s *googleSheetSelectStmt) convertArg(arg interface{}) (string, error) {
 	}
 }
 
-func (s *googleSheetSelectStmt) writeOrderBy(stmt *strings.Builder) error {
-	if len(s.orderBy) == 0 {
+func (q *queryBuilder) writeOrderBy(stmt *strings.Builder) error {
+	if len(q.orderBy) == 0 {
 		return nil
 	}
 
 	stmt.WriteString(" order by ")
-	result := make([]string, 0, len(s.orderBy))
+	result := make([]string, 0, len(q.orderBy))
 
-	for _, o := range s.orderBy {
-		result = append(result, s.replacer.Replace(o))
+	for _, o := range q.orderBy {
+		result = append(result, q.replacer.Replace(o))
 	}
 
 	stmt.WriteString(strings.Join(result, ", "))
 	return nil
 }
 
-func (s *googleSheetSelectStmt) writeOffset(stmt *strings.Builder) error {
-	if s.offset == 0 {
+func (q *queryBuilder) writeOffset(stmt *strings.Builder) error {
+	if q.offset == 0 {
 		return nil
 	}
 
 	stmt.WriteString(" offset ")
-	stmt.WriteString(strconv.FormatInt(int64(s.offset), 10))
+	stmt.WriteString(strconv.FormatInt(int64(q.offset), 10))
 	return nil
 }
 
-func (s *googleSheetSelectStmt) writeLimit(stmt *strings.Builder) error {
-	if s.limit == 0 {
+func (q *queryBuilder) writeLimit(stmt *strings.Builder) error {
+	if q.limit == 0 {
 		return nil
 	}
 
 	stmt.WriteString(" limit ")
-	stmt.WriteString(strconv.FormatInt(int64(s.limit), 10))
+	stmt.WriteString(strconv.FormatInt(int64(q.limit), 10))
 	return nil
+}
+
+func newQueryBuilder(colReplacements map[string]string, colSelected []string) *queryBuilder {
+	replacements := make([]string, 0, 2*len(colReplacements))
+	for col, repl := range colReplacements {
+		replacements = append(replacements, col, repl)
+	}
+
+	return &queryBuilder{replacer: strings.NewReplacer(replacements...), columns: colSelected}
+}
+
+type googleSheetSelectStmt struct {
+	store        *GoogleSheetRowStore
+	columns      []string
+	queryBuilder *queryBuilder
+	output       interface{}
+}
+
+func (s *googleSheetSelectStmt) Where(condition string, args ...interface{}) *googleSheetSelectStmt {
+	s.queryBuilder.Where(condition, args...)
+	return s
+}
+
+func (s *googleSheetSelectStmt) OrderBy(ordering []ColumnOrderBy) *googleSheetSelectStmt {
+	s.queryBuilder.OrderBy(ordering)
+	return s
+}
+
+func (s *googleSheetSelectStmt) Limit(limit uint64) *googleSheetSelectStmt {
+	s.queryBuilder.Limit(limit)
+	return s
+}
+
+func (s *googleSheetSelectStmt) Offset(offset uint64) *googleSheetSelectStmt {
+	s.queryBuilder.Offset(offset)
+	return s
+}
+
+func (s *googleSheetSelectStmt) Exec(ctx context.Context) error {
+	if err := s.ensureOutputSlice(); err != nil {
+		return err
+	}
+
+	stmt, err := s.queryBuilder.Generate()
+	if err != nil {
+		return err
+	}
+
+	result, err := s.store.wrapper.QueryRows(
+		ctx,
+		s.store.spreadsheetID,
+		s.store.sheetName,
+		stmt,
+		true,
+	)
+	if err != nil {
+		return err
+	}
+
+	m := s.buildQueryResultMap(result)
+	return mapstructureDecode(m, s.output)
 }
 
 func (s *googleSheetSelectStmt) buildQueryResultMap(original sheets.QueryRowsResult) []map[string]interface{} {
@@ -258,29 +264,44 @@ func (s *googleSheetSelectStmt) buildQueryResultMap(original sheets.QueryRowsRes
 	return result
 }
 
-func newGoogleSheetSelectStmt(store *GoogleSheetRowStore, output interface{}, columns []string) *googleSheetSelectStmt {
-	replacements := make([]string, 0)
-	for col, val := range store.colsMapping {
-		replacements = append(replacements, col, val.name)
+func (s *googleSheetSelectStmt) ensureOutputSlice() error {
+	// Passing an uninitialised slice will not compare to nil due to this: https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/
+	// Only if passing an untyped `nil` will compare to the `nil` in the line below.
+	// Observations as below:
+	//
+	// var o []int
+	// o == nil --> this is true because the compiler knows `o` is nil and of type `[]int`, so the `nil` on the right side is of the same `[]int` type.
+	//
+	// var x interface{} = o
+	// x == nil --> this is false because `o` has been boxed by `x` and the `nil` on the right side is of type `nil` (i.e. nil value of nil type).
+	// x == []int(nil) --> this is true because the `nil` has been casted explicitly to `nil` of type `[]int`.
+	if s.output == nil {
+		return errors.New("select statement output cannot be empty or nil")
 	}
-	return newGoogleSheetSelectStmtWithReplacer(store, output, columns, strings.NewReplacer(replacements...))
+
+	t := reflect.TypeOf(s.output)
+	if t.Kind() != reflect.Ptr {
+		return errors.New("select statement output must be a pointer to a slice of something")
+	}
+
+	elem := t.Elem()
+	if elem.Kind() != reflect.Slice {
+		return fmt.Errorf("select statement output must be a pointer to a slice of something; current output type: %s", t.Kind().String())
+	}
+
+	return nil
 }
 
-func newGoogleSheetSelectStmtWithReplacer(
-	store *GoogleSheetRowStore,
-	output interface{},
-	columns []string,
-	replacer *strings.Replacer,
-) *googleSheetSelectStmt {
+func newGoogleSheetSelectStmt(store *GoogleSheetRowStore, output interface{}, columns []string) *googleSheetSelectStmt {
 	if len(columns) == 0 {
 		columns = store.config.Columns
 	}
 
 	return &googleSheetSelectStmt{
-		store:    store,
-		replacer: replacer,
-		columns:  columns,
-		output:   output,
+		store:        store,
+		columns:      columns,
+		queryBuilder: newQueryBuilder(store.colsMapping.NameMap(), columns),
+		output:       output,
 	}
 }
 
@@ -352,22 +373,24 @@ func newGoogleSheetInsertStmt(store *GoogleSheetRowStore, rows []interface{}) *g
 }
 
 type googleSheetUpdateStmt struct {
-	store      *GoogleSheetRowStore
-	colToValue map[string]interface{}
-	where      string
-	whereArgs  []interface{}
+	store        *GoogleSheetRowStore
+	colToValue   map[string]interface{}
+	queryBuilder *queryBuilder
 }
 
 func (s *googleSheetUpdateStmt) Where(condition string, args ...interface{}) *googleSheetUpdateStmt {
-	s.where = condition
-	s.whereArgs = args
+	// The first condition `_ts IS NOT NULL` is necessary to ensure we are just updating rows that are non-empty.
+	// This is required for UPDATE without WHERE clause (otherwise it will see every row as update target).
+	if condition == "" {
+		s.queryBuilder.Where(fmt.Sprintf(rowUpdateModifyWhereEmptyTemplate, rowTsCol), args...)
+	} else {
+		s.queryBuilder.Where(fmt.Sprintf(rowUpdateModifyWhereNonEmptyTemplate, rowTsCol, condition), args...)
+	}
 	return s
 }
 
 func (s *googleSheetUpdateStmt) Exec(ctx context.Context) error {
-	// The first _ts IS NOT NULL is necessary to ensure we are just updating rows that are non-empty.
-	// This is required for UPDATE without WHERE clause (otherwise it will see every row as update target).
-	selectStmt, err := generateSelectQuery(s.store, s.generateWhere(), s.whereArgs)
+	selectStmt, err := s.queryBuilder.Generate()
 	if err != nil {
 		return err
 	}
@@ -387,13 +410,6 @@ func (s *googleSheetUpdateStmt) Exec(ctx context.Context) error {
 
 	_, err = s.store.wrapper.BatchUpdateRows(ctx, s.store.spreadsheetID, requests)
 	return err
-}
-
-func (s *googleSheetUpdateStmt) generateWhere() string {
-	if s.where == "" {
-		return fmt.Sprintf(rowUpdateModifyWhereEmptyTemplate, rowTsCol)
-	}
-	return fmt.Sprintf(rowUpdateModifyWhereNonEmptyTemplate, rowTsCol, s.where)
 }
 
 func (s *googleSheetUpdateStmt) generateBatchUpdateRequests(rowIndices []int) ([]sheets.BatchUpdateRowsRequest, error) {
@@ -419,25 +435,24 @@ func (s *googleSheetUpdateStmt) generateBatchUpdateRequests(rowIndices []int) ([
 
 func newGoogleSheetUpdateStmt(store *GoogleSheetRowStore, colToValue map[string]interface{}) *googleSheetUpdateStmt {
 	return &googleSheetUpdateStmt{
-		store:      store,
-		colToValue: colToValue,
+		store:        store,
+		colToValue:   colToValue,
+		queryBuilder: newQueryBuilder(store.colsMapping.ColIdxNameMap(), []string{lastColIdxName}),
 	}
 }
 
 type googleSheetDeleteStmt struct {
-	store     *GoogleSheetRowStore
-	where     string
-	whereArgs []interface{}
+	store        *GoogleSheetRowStore
+	queryBuilder *queryBuilder
 }
 
 func (s *googleSheetDeleteStmt) Where(condition string, args ...interface{}) *googleSheetDeleteStmt {
-	s.where = condition
-	s.whereArgs = args
+	s.queryBuilder.Where(condition, args...)
 	return s
 }
 
 func (s *googleSheetDeleteStmt) Exec(ctx context.Context) error {
-	selectStmt, err := generateSelectQuery(s.store, s.where, s.whereArgs)
+	selectStmt, err := s.queryBuilder.Generate()
 	if err != nil {
 		return err
 	}
@@ -455,25 +470,24 @@ func (s *googleSheetDeleteStmt) Exec(ctx context.Context) error {
 }
 
 func newGoogleSheetDeleteStmt(store *GoogleSheetRowStore) *googleSheetDeleteStmt {
-	return &googleSheetDeleteStmt{store: store}
+	return &googleSheetDeleteStmt{
+		store:        store,
+		queryBuilder: newQueryBuilder(store.colsMapping.ColIdxNameMap(), []string{lastColIdxName}),
+	}
 }
 
 type googleSheetCountStmt struct {
-	store     *GoogleSheetRowStore
-	where     string
-	whereArgs []interface{}
+	store        *GoogleSheetRowStore
+	queryBuilder *queryBuilder
 }
 
 func (s *googleSheetCountStmt) Where(condition string, args ...interface{}) *googleSheetCountStmt {
-	s.where = condition
-	s.whereArgs = args
+	s.queryBuilder.Where(condition, args...)
 	return s
 }
 
 func (s *googleSheetCountStmt) Exec(ctx context.Context) (uint64, error) {
-	selectStmt, err := newGoogleSheetSelectStmt(s.store, nil, []string{rowTsCol}).
-		Where(s.where, s.whereArgs...).
-		generateSelect()
+	selectStmt, err := s.queryBuilder.Generate()
 	if err != nil {
 		return 0, err
 	}
@@ -505,19 +519,10 @@ func (s *googleSheetCountStmt) Exec(ctx context.Context) (uint64, error) {
 }
 
 func newGoogleSheetCountStmt(store *GoogleSheetRowStore) *googleSheetCountStmt {
-	return &googleSheetCountStmt{store: store}
-}
-
-func generateSelectQuery(store *GoogleSheetRowStore, where string, whereArgs []interface{}) (string, error) {
-	replacements := make([]string, 0)
-	for col, val := range store.colsMapping {
-		replacements = append(replacements, col, "Col"+strconv.FormatInt(int64(val.idx+1), 10))
+	return &googleSheetCountStmt{
+		store:        store,
+		queryBuilder: newQueryBuilder(store.colsMapping.NameMap(), []string{rowTsCol}),
 	}
-
-	col := []string{"Col" + strconv.FormatInt(int64(maxColumn+1), 10)}
-	return newGoogleSheetSelectStmtWithReplacer(store, nil, col, strings.NewReplacer(replacements...)).
-		Where(where, whereArgs...).
-		generateSelect()
 }
 
 func getRowIndices(ctx context.Context, store *GoogleSheetRowStore, selectStmt string) ([]int, error) {

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -18,7 +18,7 @@ type person struct {
 func TestGenerateSelect(t *testing.T) {
 	t.Run("successful_basic", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 
@@ -29,7 +29,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("successful_all_columns", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 			config:      GoogleSheetRowStoreConfig{Columns: []string{"col1", "col2"}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{})
@@ -41,7 +41,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("unsuccessful_basic_wrong_column", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2", "col3"})
 
@@ -52,7 +52,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("successful_with_where", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 		stmt.Where("(col1 > ? AND col2 <= ?) OR (col1 != ? AND col2 == ?)", 100, true, "value", 3.14)
@@ -64,7 +64,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("unsuccessful_with_where_wrong_arg_count", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 		stmt.Where("(col1 > ? AND col2 <= ?) OR (col1 != ? AND col2 == ?)", 100, true)
@@ -76,7 +76,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("unsuccessful_with_where_unsupported_arg_type", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 		stmt.Where("(col1 > ? AND col2 <= ?) OR (col1 != ? AND col2 == ?)", 100, true, nil, []string{})
@@ -88,7 +88,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("successful_with_limit_offset", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 		stmt.Limit(10).Offset(100)
@@ -100,7 +100,7 @@ func TestGenerateSelect(t *testing.T) {
 
 	t.Run("successful_with_order_by", func(t *testing.T) {
 		store := &GoogleSheetRowStore{
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"C", 2}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 		stmt.OrderBy([]ColumnOrderBy{{Column: "col1", OrderBy: OrderByDesc}, {Column: "col2", OrderBy: OrderByAsc}})
@@ -116,7 +116,7 @@ func TestSelectStmt_Exec(t *testing.T) {
 		wrapper := &sheets.MockWrapper{}
 		store := &GoogleSheetRowStore{
 			wrapper:     wrapper,
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"D", 3}},
 		}
 		o := 0
 		stmt := newGoogleSheetSelectStmt(store, &o, []string{"col1", "col2"})
@@ -128,7 +128,7 @@ func TestSelectStmt_Exec(t *testing.T) {
 		wrapper := &sheets.MockWrapper{}
 		store := &GoogleSheetRowStore{
 			wrapper:     wrapper,
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"D", 3}},
 		}
 		var o []int
 		stmt := newGoogleSheetSelectStmt(store, o, []string{"col1", "col2"})
@@ -140,7 +140,7 @@ func TestSelectStmt_Exec(t *testing.T) {
 		wrapper := &sheets.MockWrapper{}
 		store := &GoogleSheetRowStore{
 			wrapper:     wrapper,
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"D", 3}},
 		}
 		stmt := newGoogleSheetSelectStmt(store, nil, []string{"col1", "col2"})
 
@@ -151,7 +151,7 @@ func TestSelectStmt_Exec(t *testing.T) {
 		wrapper := &sheets.MockWrapper{QueryRowsError: errors.New("some error")}
 		store := &GoogleSheetRowStore{
 			wrapper:     wrapper,
-			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}},
+			colsMapping: map[string]colIdx{"col1": {"A", 0}, "col2": {"B", 1}, "_ts": {"D", 3}},
 		}
 		var out []int
 		stmt := newGoogleSheetSelectStmt(store, &out, []string{"col1", "col2"})
@@ -167,7 +167,7 @@ func TestSelectStmt_Exec(t *testing.T) {
 		}}}
 		store := &GoogleSheetRowStore{
 			wrapper:     wrapper,
-			colsMapping: map[string]colIdx{"name": {"A", 0}, "age": {"B", 1}, "dob": {"C", 2}},
+			colsMapping: map[string]colIdx{"name": {"A", 0}, "age": {"B", 1}, "dob": {"C", 2}, "_ts": {"D", 3}},
 			config: GoogleSheetRowStoreConfig{
 				Columns: []string{"name", "age", "dob"},
 			},
@@ -192,7 +192,7 @@ func TestSelectStmt_Exec(t *testing.T) {
 		}}}
 		store := &GoogleSheetRowStore{
 			wrapper:     wrapper,
-			colsMapping: map[string]colIdx{"name": {"A", 0}, "age": {"B", 1}, "dob": {"C", 2}},
+			colsMapping: map[string]colIdx{"name": {"A", 0}, "age": {"B", 1}, "dob": {"C", 2}, "_ts": {"D", 3}},
 			config: GoogleSheetRowStoreConfig{
 				Columns: []string{"name", "age", "dob"},
 			},
@@ -215,28 +215,29 @@ func TestGoogleSheetInsertStmt_convertRowToSlice(t *testing.T) {
 	wrapper := &sheets.MockWrapper{}
 	store := &GoogleSheetRowStore{
 		wrapper:     wrapper,
-		colsMapping: map[string]colIdx{"name": {"A", 0}, "age": {"B", 1}, "dob": {"C", 2}},
+		colsMapping: map[string]colIdx{"name": {"A", 0}, "age": {"B", 1}, "dob": {"C", 2}, "_ts": {"D", 3}},
 		config: GoogleSheetRowStoreConfig{
 			Columns: []string{"name", "age", "dob"},
 		},
 	}
+	ts := int64(1)
 
 	t.Run("non_struct", func(t *testing.T) {
 		stmt := newGoogleSheetInsertStmt(store, nil)
 
-		result, err := stmt.convertRowToSlice(nil)
+		result, err := stmt.convertRowToSlice(nil, ts)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 
-		result, err = stmt.convertRowToSlice(1)
+		result, err = stmt.convertRowToSlice(1, ts)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 
-		result, err = stmt.convertRowToSlice("1")
+		result, err = stmt.convertRowToSlice("1", ts)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 
-		result, err = stmt.convertRowToSlice([]int{1, 2, 3})
+		result, err = stmt.convertRowToSlice([]int{1, 2, 3}, ts)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 	})
@@ -244,24 +245,24 @@ func TestGoogleSheetInsertStmt_convertRowToSlice(t *testing.T) {
 	t.Run("struct", func(t *testing.T) {
 		stmt := newGoogleSheetInsertStmt(store, nil)
 
-		result, err := stmt.convertRowToSlice(person{Name: "blah", Age: 10, DOB: "2021"})
-		assert.Equal(t, []interface{}{"blah", 10, "2021"}, result)
+		result, err := stmt.convertRowToSlice(person{Name: "blah", Age: 10, DOB: "2021"}, ts)
+		assert.Equal(t, []interface{}{"blah", 10, "2021", ts}, result)
 		assert.Nil(t, err)
 
-		result, err = stmt.convertRowToSlice(&person{Name: "blah", Age: 10, DOB: "2021"})
-		assert.Equal(t, []interface{}{"blah", 10, "2021"}, result)
+		result, err = stmt.convertRowToSlice(&person{Name: "blah", Age: 10, DOB: "2021"}, ts)
+		assert.Equal(t, []interface{}{"blah", 10, "2021", ts}, result)
 		assert.Nil(t, err)
 
-		result, err = stmt.convertRowToSlice(person{Name: "blah", DOB: "2021"})
-		assert.Equal(t, []interface{}{"blah", nil, "2021"}, result)
+		result, err = stmt.convertRowToSlice(person{Name: "blah", DOB: "2021"}, ts)
+		assert.Equal(t, []interface{}{"blah", nil, "2021", ts}, result)
 		assert.Nil(t, err)
 
 		type dummy struct {
 			Name string `db:"name"`
 		}
 
-		result, err = stmt.convertRowToSlice(dummy{Name: "blah"})
-		assert.Equal(t, []interface{}{"blah", nil, nil}, result)
+		result, err = stmt.convertRowToSlice(dummy{Name: "blah"}, ts)
+		assert.Equal(t, []interface{}{"blah", nil, nil, ts}, result)
 		assert.Nil(t, err)
 	})
 }


### PR DESCRIPTION
Implement the following changes:

1. Add `Count()` implementation.
2. Refactor the query building part into a separate struct (following the idea implemented in `PyFreeLeh`).
3. Change the `_ts` magic column to `_rid` to track the row index.
4. Remove `RawInsert` and implement `Insert()` that takes in a slice of structs or a slice of pointers to structs.